### PR TITLE
Added check if trigger function exists

### DIFF
--- a/dist/ngCropper.all.js
+++ b/dist/ngCropper.all.js
@@ -212,8 +212,9 @@
     }
 
     buildEvent = $.Event(EVENT_BUILD);
-    $this.one(EVENT_BUILD, options.build).trigger(buildEvent); // Only trigger once
-
+    if($this.one(EVENT_BUILD, options.build).trigger){
+      $this.one(EVENT_BUILD, options.build).trigger(buildEvent); // Only trigger once
+    }
     if (buildEvent.isDefaultPrevented()) {
       return;
     }
@@ -325,7 +326,9 @@
     this.built = true;
     this.render();
     this.setData(options.data);
-    $this.one(EVENT_BUILT, options.built).trigger(EVENT_BUILT); // Only trigger once
+    if($this.one(EVENT_BUILT, options.built).trigger){
+      $this.one(EVENT_BUILT, options.built).trigger(EVENT_BUILT); // Only trigger once
+    }
   };
 
   prototype.unbuild = function () {


### PR DESCRIPTION
The reason I added this is because I got the error "trigger is not a function" over and over again, and it rendered the plugin useless. By adding these if-statements this error is circumvented, without removing the functionality that you originally intended here.
